### PR TITLE
fix npx prisma generate error

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,5 +1,6 @@
 FROM node:16-alpine AS BUILD_IMAGE
 
+RUN apk add openssl1.1-compat
 
 # install dependencies
 WORKDIR /app
@@ -17,6 +18,8 @@ RUN npm run build
 RUN npm prune --production
 
 FROM node:16-alpine
+
+RUN apk add openssl1.1-compat
 
 WORKDIR /app
 COPY --from=0 /app .


### PR DESCRIPTION
When we want to do a `docker-compose build` we get an error when building the server image.

```text
------
 > [dev_backend build_image 6/8] RUN npx prisma generate:
#0 4.156 Prisma schema loaded from prisma/schema.prisma
#0 5.001 Error: Get Config: Unable to establish a connection to query-engine-node-api library.
#0 5.001 Details: Unable to require(`/app/node_modules/prisma/libquery_engine-linux-musl.so.node`)
#0 5.001  Error loading shared library libssl.so.1.1: No such file or directory (needed by /app/node_modules/prisma/libquery_engine-linux-musl.so.node)
#0 5.001
#0 5.001 Prisma CLI Version : 4.2.0
------
```

The only thing missing is the openssl dependency in the server Dockerfile.