### PR TITLE
Expose expiry period for notes as environment variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,8 @@ services:
       # Rate limit for downloading notes
       - GET_LIMIT_WINDOW_SECONDS=60
       - GET_LIMIT=20
+      # Duration in days that notes are kept
+      - EXPIRE_WINDOW_DAYS=30
     depends_on:
       migrate:
         condition: service_completed_successfully

--- a/server/.env.example
+++ b/server/.env.example
@@ -20,6 +20,9 @@ DATABASE_URL="file:./dev.sqlite"
 # and expired notes are deleted.
 CLEANUP_INTERVAL_SECONDS=60
 
+# Duration in days that notes are kept, after which they are expired.
+EXPIRE_WINDOW_DAYS=30
+
 # Rate limit for uploading notes.
 POST_LIMIT_WINDOW=86400
 POST_LIMIT=50

--- a/server/.env.test
+++ b/server/.env.test
@@ -6,6 +6,7 @@ POST_LIMIT_WINDOW_SECONDS=0.25
 GET_LIMIT=20
 GET_LIMIT_WINDOW_SECONDS=0.1
 LOG_LEVEL=warn
+EXPIRE_WINDOW_DAYS=30
 
 # Make cleanup interval very long to avoid automatic cleanup during tests
 CLEANUP_INTERVAL_SECONDS=99999

--- a/server/src/controllers/note/note.post.controller.ts
+++ b/server/src/controllers/note/note.post.controller.ts
@@ -47,14 +47,13 @@ export async function postNoteController(
   }
 
   // Create note object
-  const EXPIRE_WINDOW_DAYS = 30;
   const secret_token = generateToken();
 
   const note = {
     ciphertext: notePostRequest.ciphertext as string,
     hmac: notePostRequest.hmac as string,
     iv: notePostRequest.iv as string,
-    expire_time: addDays(new Date(), EXPIRE_WINDOW_DAYS),
+    expire_time: addDays(new Date(), process.env(EXPIRE_WINDOW_DAYS)),
     crypto_version: notePostRequest.crypto_version,
     secret_token: secret_token,
   } as EncryptedNote;
@@ -65,7 +64,7 @@ export async function postNoteController(
       event.success = true;
       event.note_id = savedNote.id;
       event.size_bytes = getNoteSize(note);
-      event.expire_window_days = EXPIRE_WINDOW_DAYS;
+      event.expire_window_days = process.env(EXPIRE_WINDOW_DAYS);
       await EventLogger.writeEvent(event);
       res.json({
         view_url: `${process.env.FRONTEND_URL}/note/${savedNote.id}`,


### PR DESCRIPTION
Added an environment variable, `EXPIRE_WINDOW_DAYS`, to be able to easily set how many days notes are kept before they're deleted.